### PR TITLE
Fix 5 second blocking delay for keyboard and mouse

### DIFF
--- a/src/hidboot.h
+++ b/src/hidboot.h
@@ -464,6 +464,7 @@ void HIDBoot<BOOT_PROTOCOL>::EndpointXtract(uint32_t conf, uint32_t iface, uint3
 		epInfo[index].deviceEpNum		= (pep->bEndpointAddress & 0x0F);
 		epInfo[index].maxPktSize	= (uint8_t)pep->wMaxPacketSize;
 		epInfo[index].epAttribs		= 0;
+		epInfo[index].bmNakPower	= USB_NAK_NOWAIT;
 
 		TRACE_USBHOST(printf("HIDBoot::EndpointXtract : Found new endpoint\r\n");)
 		TRACE_USBHOST(printf("HIDBoot::EndpointXtract : deviceEpNum: %lu\r\n", epInfo[index].deviceEpNum);)


### PR DESCRIPTION
I need this fix so that my usb.Task() does not block when there is no input at the keyboard.